### PR TITLE
Fixed the resize hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agility/app-sdk",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "JavaScript library for building Agility CMS apps.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/hooks/useResizeHeight.tsx
+++ b/src/hooks/useResizeHeight.tsx
@@ -1,31 +1,29 @@
-import {  useEffect, RefObject } from "react"
+import { useCallback } from "react"
 import { setHeight } from "../methods"
 
-interface Props {
-  ref: RefObject<HTMLElement>
-  padding?: number
-}
-
 /**
- * useResizeHeight detects the height of the current ref object, and triggers the setHeight method to update the Content Manager
- * @param ref - html ref.
- * @param padding - optional additional padding for the height
+ * useResizeHeight
+ * @param padding 
+ * @returns a ref callback, that executes anytime a ref is attached to an element
  */
-const useResizeHeight = ({ ref, padding = 0 }: Props) => {
-  useEffect(() => {
-    const mdeSizeElm = ref?.current
-    if (!mdeSizeElm) return
+const useResizeHeight = (padding?: number) => {
+ 
+  // Object refs don't trigger useEffect re-renders, so instead, use a ref-callback
+  // to determine when a ref is attached to a node.
+  return useCallback((node: any) => {
+    if (node !== null) {
+      // when ref attaches to node (node !== null) attach observable
+      const observer = new ResizeObserver((entries) => {
+        const entry = entries[0]
+        if (!entry) return
+        // any time there's a resize event on this node, trigger setHeight in the sdk.
+        const p = padding ?? 0 // if padding is undefined then set to 0
+        setHeight({ height: entry.contentRect.height + p })
+      })
 
-    const observer = new ResizeObserver((entries) => {
-      const entry = entries[0]
-      if (!entry) return
-      // with a little extra height as padding
-      setHeight({ height: entry.contentRect.height + padding })
-    })
-
-    observer.observe(mdeSizeElm)
-    return () => observer.disconnect()
-  }, [ref?.current])
+      observer.observe(node)
+    }
+  }, [])
 }
 
 export default useResizeHeight


### PR DESCRIPTION
Instead of passing in a Ref Object, we'll instead use a Ref Callback, to determine when a ref has attached to the node.
Then on initial render of the node, we can attach the observer that will trigger the setHeight SDK method.